### PR TITLE
Guage.xsd update

### DIFF
--- a/Gauges/gauge.xsd
+++ b/Gauges/gauge.xsd
@@ -250,8 +250,35 @@
           <xs:element minOccurs="0" maxOccurs="1" name="Value" type="ValueDefinition" />
           <xs:element minOccurs="0" maxOccurs="1" name="ImageRotationDegrees" type="xs:int" />
           <xs:element minOccurs="0" maxOccurs="1" name="currentAngle" type="xs:double" />
+          <xs:element minOccurs="0" maxOccurs="1" name="Failures" type="Failures"/>
         </xs:all>
   </xs:complexType>
+  <xs:complexType name="Failures">
+    <xs:all>
+      <xs:element minOccurs="0" maxOccurs="1" name="NONE" type="Failure"  />
+      <xs:element minOccurs="0" maxOccurs="1" name="SYSTEM_ENGINE" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="SYSTEM_PITOT_STATIC" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="SYSTEM_VACUUM" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_ADF" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_AIRSPEED" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_ALTIMETER" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_COMMUNICATIONS" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_FUEL_INDICATORS" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_GYRO_HEADING" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_MAGNETIC_COMPASS" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_NAVIGATION_VOR1" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_NAVIGATION_VOR2" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_TRANSPONDER" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_TURN_COORDINATOR" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_VERTICAL_SPEED" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_ELECTRICAL_PANEL" type="Failure" />
+      <xs:element minOccurs="0" maxOccurs="1" name="GAUGE_ELECTRICAL_AVIONICS" type="Failure" />
+      </xs:all>
+  </xs:complexType>
+    <xs:complexType name="Failure">
+      <xs:attribute name="Name" type="xs:string" />
+      <xs:attribute name="Action" type="Fail_Action" />
+    </xs:complexType>
   <xs:complexType name="GaugeImage">
     <xs:all>
           <xs:element minOccurs="0" maxOccurs="1" name="Nonlinearity" type="ArrayOfNonlinearityItem" />
@@ -263,11 +290,17 @@
           <xs:element minOccurs="0" maxOccurs="1" name="ID" type="xs:string" />
         </xs:all>
         <xs:attribute name="PointsTo" type="ImageDirection"  />
+        <xs:attribute name="DegreesPointsTo" type="xs:double" />
         <xs:attribute name="Name" type="xs:string" />
-        <xs:attribute name="ImageSizes" type="xs:string" />
+        <xs:attribute name="ImageSizes" type="ImageSizes" />
         <xs:attribute name="Alpha" type="xs:boolean" />
         <xs:attribute name="Dynamic" type="xs:string" />
   </xs:complexType>
+  <xs:simpleType name="ImageSizes">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9]+,[0-9]+,[0-9]+,[0-9]+"></xs:pattern>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="ImageDirection">
     <xs:restriction base="xs:string">
       <xs:enumeration value="East" />
@@ -275,6 +308,15 @@
       <xs:enumeration value="West" />
       <xs:enumeration value="North" />
       <xs:enumeration value="Invalid" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Fail_Action">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="None" />
+      <xs:enumeration value="Freeze" />
+      <xs:enumeration value="Zero" />
+      <xs:enumeration value="Cover" />
+      <xs:enumeration value="NoDraw" />
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="MaskImage">

--- a/Gauges/gauge.xsd
+++ b/Gauges/gauge.xsd
@@ -242,6 +242,7 @@
           <xs:element minOccurs="0" maxOccurs="1" name="Nonlinearity" type="ArrayOfNonlinearityItem" />
           <xs:element minOccurs="0" maxOccurs="1" name="Scale" type="Position" />
           <xs:element minOccurs="0" maxOccurs="1" name="DirectionVector" type="Position" />
+          <xs:element minOccurs="0" maxOccurs="1" name="Failures" type="Failures"/>
         </xs:all>
   </xs:complexType>
   <xs:complexType name="Rotate">

--- a/Gauges/readme.md
+++ b/Gauges/readme.md
@@ -1,0 +1,14 @@
+#Saitek FIP Gauge Support in SPAD.neXt
+##Overview
+This readme is to provide a starter for information on Saitek FIP Gauges, in SPAD.neXt, mostly based on links to other sources plus some pointers.  A reliable link to Saitek FIP Gauge programming is not available from Saitek or Logitech (current manufacturer of the FIP).
+
+General information on XML Gauges can be found in the FSX and Prepar3d SDKs.  Specifically the Prepar3d V5 SDK documentation on creating XML gauges can be found [here](http://www.prepar3d.com/SDK/SimObject%20Creation%20Kit/Panels%20and%20Gauges%20SDK/creating%20xml%20gauges.html#XML%20Gauge%20Reference).
+
+Gauges XSD file in this repository is used to validate format of the gauge xml files for Saitek FIPs, with specific extentions for SPAD.neXt
+
+Information on SPAD.neXt extensions can be found [here](https://www.spadnext.com/wiki/gauges:spad.next_extensions).
+
+##Images
+Images are stored under the main guage directory in a sub directory named **1024**.  
+The Saitek FIP has a display resolution of 320 x 240
+When adding images in the gauges XML, use the attribute ImageSizes="x,y,w,z" where x AND w are the image width, and y AND z are the image height (

--- a/Gauges/readme.md
+++ b/Gauges/readme.md
@@ -10,6 +10,8 @@ Gauges XSD file in this repository is used to validate format of the gauge xml f
 
 Information on SPAD.neXt extensions can be found [here](https://www.spadnext.com/wiki/gauges:spad.next_extensions).
 
+FS 2004 tutorial on creating gauges [here](http://fs2x.com/Tutorials_files/XML%20Gauge%20Programming%20for%20FS2004.%20Chapter%201.%20Main%20Body%20Sections%20V2_0.pdf)
+
 ## Images
 Images are stored under the main guage directory in a sub directory named **1024**.  
 The Saitek FIP has a display resolution of 320 x 240

--- a/Gauges/readme.md
+++ b/Gauges/readme.md
@@ -1,5 +1,7 @@
-#Saitek FIP Gauge Support in SPAD.neXt
-##Overview
+# Saitek FIP Gauge Support in SPAD.neXt
+
+## Overview
+
 This readme is to provide a starter for information on Saitek FIP Gauges, in SPAD.neXt, mostly based on links to other sources plus some pointers.  A reliable link to Saitek FIP Gauge programming is not available from Saitek or Logitech (current manufacturer of the FIP).
 
 General information on XML Gauges can be found in the FSX and Prepar3d SDKs.  Specifically the Prepar3d V5 SDK documentation on creating XML gauges can be found [here](http://www.prepar3d.com/SDK/SimObject%20Creation%20Kit/Panels%20and%20Gauges%20SDK/creating%20xml%20gauges.html#XML%20Gauge%20Reference).
@@ -8,7 +10,7 @@ Gauges XSD file in this repository is used to validate format of the gauge xml f
 
 Information on SPAD.neXt extensions can be found [here](https://www.spadnext.com/wiki/gauges:spad.next_extensions).
 
-##Images
+## Images
 Images are stored under the main guage directory in a sub directory named **1024**.  
 The Saitek FIP has a display resolution of 320 x 240
 When adding images in the gauges XML, use the attribute ImageSizes="x,y,w,z" where x AND w are the image width, and y AND z are the image height (


### PR DESCRIPTION
Some suggested changes to gauge.xsd to add
1) Failures (with failure types from prepar3d v5)
2) DegreesPointsTo attribute for Images
3) Pattern validation of the ImageSizes attribute

There is also a readme.md file for some notes I have made on sources of information.  Assume it is less likely you want to add this.

Please let me know if you would rather not have contributions to gauge.xsd, otherwise I will continue to build it out if I find more missing elements as I dig into creating xml gauges.  -  Which by the way, I find image sizing and positioning on FIPs to be aggravating to say the least - I must be missing something.